### PR TITLE
sumdb/note: remove stray bytes.Buffer from Open

### DIFF
--- a/sumdb/note/note.go
+++ b/sumdb/note/note.go
@@ -549,9 +549,6 @@ func Open(msg []byte, known Verifiers) (*Note, error) {
 		Text: string(text),
 	}
 
-	var buf bytes.Buffer
-	buf.Write(text)
-
 	// Parse and verify signatures.
 	// Ignore duplicate signatures.
 	seen := make(map[nameHash]bool)


### PR DESCRIPTION
This has been there from the beginning (CL 156324) without ever being
used.