### PR TITLE
modfile: take into account that // indirect comments may not be well formatted

### DIFF
--- a/modfile/rule.go
+++ b/modfile/rule.go
@@ -505,8 +505,8 @@ func setIndirect(line *Line, indirect bool) {
 	}
 
 	// Removing comment.
-	f := strings.TrimSpace(strings.ReplaceAll(line.Suffix[0].Token, " ", ""))
-	if f == "//indirect" {
+	f := strings.TrimSpace(strings.TrimPrefix(line.Suffix[0].Token, string(slashSlash)))
+	if f == "indirect" {
 		// Remove whole comment.
 		line.Suffix = nil
 		return

--- a/modfile/rule.go
+++ b/modfile/rule.go
@@ -505,8 +505,8 @@ func setIndirect(line *Line, indirect bool) {
 	}
 
 	// Removing comment.
-	f := strings.Fields(line.Suffix[0].Token)
-	if len(f) == 2 {
+	f := strings.TrimSpace(strings.ReplaceAll(line.Suffix[0].Token, " ", ""))
+	if f == "//indirect" {
 		// Remove whole comment.
 		line.Suffix = nil
 		return

--- a/modfile/rule_test.go
+++ b/modfile/rule_test.go
@@ -77,6 +77,32 @@ var setRequireTests = []struct {
 	out string
 }{
 	{
+		`https://golang.org/issue/45932`,
+		`module m
+		require (
+			x.y/a v1.2.3 //indirect
+			x.y/b v1.2.3
+			x.y/c v1.2.3
+		)
+		`,
+		[]struct {
+			path     string
+			vers     string
+			indirect bool
+		}{
+			{"x.y/a", "v1.2.3", false},
+			{"x.y/b", "v1.2.3", false},
+			{"x.y/c", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/b v1.2.3
+			x.y/c v1.2.3
+		)
+		`,
+	},
+	{
 		`existing`,
 		`module m
 		require (


### PR DESCRIPTION
When there is an // indirect comment next to a dependency that is not actually indirect;
go mod tidy should remove it.
This was not the case when the //indirect comment was badly formatted.

We now check whether such a comment exists irrespective of the formatting.

Updates golang/go#45932