### PR TITLE
module: accept trailing slash in MatchPrefixPattern

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -798,6 +798,7 @@ func unescapeString(escaped string) (string, bool) {
 // GOPRIVATE environment variable, as described by 'go help module-private'.
 //
 // It ignores any empty or malformed patterns in the list.
+// Trailing slashes on patterns are ignored.
 func MatchPrefixPatterns(globs, target string) bool {
 	for globs != "" {
 		// Extract next non-empty glob in comma-separated list.
@@ -807,6 +808,7 @@ func MatchPrefixPatterns(globs, target string) bool {
 		} else {
 			glob, globs = globs, ""
 		}
+		glob = strings.TrimSuffix(glob, "/")
 		if glob == "" {
 			continue
 		}

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -353,6 +353,8 @@ func TestMatchPrefixPatterns(t *testing.T) {
 		globs, target string
 		want          bool
 	}{
+		{"", "rsc.io/quote", false},
+		{"/", "rsc.io/quote", false},
 		{"*/quote", "rsc.io/quote", true},
 		{"*/quo", "rsc.io/quote", false},
 		{"*/quo??", "rsc.io/quote", true},
@@ -360,17 +362,21 @@ func TestMatchPrefixPatterns(t *testing.T) {
 		{"*quo*", "rsc.io/quote", false},
 		{"rsc.io", "rsc.io/quote", true},
 		{"*.io", "rsc.io/quote", true},
-		{"rsc.io/", "rsc.io/quote", false},
+		{"rsc.io/", "rsc.io/quote", true},
 		{"rsc", "rsc.io/quote", false},
 		{"rsc*", "rsc.io/quote", true},
 
 		{"rsc.io", "rsc.io/quote/v3", true},
 		{"*/quote", "rsc.io/quote/v3", true},
+		{"*/quote/", "rsc.io/quote/v3", true},
 		{"*/quote/*", "rsc.io/quote/v3", true},
+		{"*/quote/*/", "rsc.io/quote/v3", true},
 		{"*/v3", "rsc.io/quote/v3", false},
 		{"*/*/v3", "rsc.io/quote/v3", true},
 		{"*/*/*", "rsc.io/quote/v3", true},
+		{"*/*/*/", "rsc.io/quote/v3", true},
 		{"*/*/*", "rsc.io/quote", false},
+		{"*/*/*/", "rsc.io/quote", false},
 
 		{"*/*/*,,", "rsc.io/quote", false},
 		{"*/*/*,,*/quote", "rsc.io/quote", true},


### PR DESCRIPTION
Trailing slash of glob was not accepted in MatchPrefixPattern. This
CL starts to accept the trailing slash.