### PR TITLE
Fix Compare function

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -317,17 +317,10 @@ func compareInt(x, y string) int {
 	if x == y {
 		return 0
 	}
-	if len(x) < len(y) {
-		return -1
-	}
-	if len(x) > len(y) {
-		return +1
-	}
 	if x < y {
 		return -1
-	} else {
-		return +1
 	}
+	return +1
 }
 
 func comparePrerelease(x, y string) int {

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -154,6 +154,22 @@ func TestCompare(t *testing.T) {
 			}
 		}
 	}
+
+	// These additional tests are for explicitly comparing versions
+	for _, tt := range []struct {
+		v, w string
+		r    int
+	}{
+		{"v1", "v1", 0},
+		{"v2", "v1", 1},
+		{"v1", "v2", -1},
+		{"v1.19", "v1.2", -1},
+	} {
+		cmp := Compare(tt.v, tt.w)
+		if cmp != tt.r {
+			t.Errorf("Compare(%q, %q) = %d, want %d", tt.v, tt.w, cmp, tt.r)
+		}
+	}
 }
 
 func TestSort(t *testing.T) {


### PR DESCRIPTION
Hi! Sorry for cold-opening a PR against this repo, but I couldn't easily find how to submit a but report. I've found that using `semver.Compare("1.19", "1.2")` was wrongfully returning `1` instead of `-1`. This PR takes advantage of Go comparing strings lexicographically instead of by their length as the original implementation.

I've added some additional tests for this particular case. I hope this helps.