### PR TITLE
Hash1: Make comment more precisely describe how to emulate logic from shell

### DIFF
--- a/sumdb/dirhash/hash.go
+++ b/sumdb/dirhash/hash.go
@@ -33,7 +33,9 @@ type Hash func(files []string, open func(string) (io.ReadCloser, error)) (string
 // Hash1 is "h1:" followed by the base64-encoded SHA-256 hash of a summary
 // prepared as if by the Unix command:
 //
-//	find . -type f | sort | sha256sum
+//	find . -type f -printf 'prefix/%P\n' | sort | xargs sha256sum
+//
+// (where prefix is something like foo/bar@v1.2.3)
 //
 // More precisely, the hashed summary contains a single line for each file in the list,
 // ordered by sort.Strings applied to the file names, where each line consists of


### PR DESCRIPTION
The shell command previously given as an example emits paths starting with `./`, and without an added prefix. Also, previously, `sha256` was run against the sorted list of filenames, not against the _contents_ of
those files (`xargs` is needed to perform the latter).

This does introduce a GNUism; working with POSIX `find` might involve adding a `sed` pipeline element.