### PR TITLE
x/mod/sumdb/dirhash: fix unix command provided in comment

### DIFF
--- a/sumdb/dirhash/hash.go
+++ b/sumdb/dirhash/hash.go
@@ -33,7 +33,7 @@ type Hash func(files []string, open func(string) (io.ReadCloser, error)) (string
 // Hash1 is "h1:" followed by the base64-encoded SHA-256 hash of a summary
 // prepared as if by the Unix command:
 //
-//	find . -type f | sort | sha256sum
+//	find . -type f | sort | xargs sha256sum | sha256sum
 //
 // More precisely, the hashed summary contains a single line for each file in the list,
 // ordered by sort.Strings applied to the file names, where each line consists of


### PR DESCRIPTION
Fix unix command provided since Hash1 function will take the hash of input files iteratively 
before coming up the final outcome. 

Fix #48498