### PR TITLE
all: replace io/ioutil with io and os package

### DIFF
--- a/gosumcheck/main.go
+++ b/gosumcheck/main.go
@@ -34,7 +34,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -84,7 +83,7 @@ func main() {
 	client.SetGONOSUMDB(env)
 
 	for _, arg := range flag.Args() {
-		data, err := ioutil.ReadFile(arg)
+		data, err := os.ReadFile(arg)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -201,7 +200,7 @@ func (*clientOps) ReadRemote(path string) ([]byte, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("GET %v: %v", target, resp.Status)
 	}
-	data, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, err
 	}

--- a/modfile/read_test.go
+++ b/modfile/read_test.go
@@ -7,7 +7,6 @@ package modfile
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,13 +42,13 @@ func TestPrintGolden(t *testing.T) {
 // It reads the file named in, reformats it, and compares
 // the result to the file named out.
 func testPrint(t *testing.T, in, out string) {
-	data, err := ioutil.ReadFile(in)
+	data, err := os.ReadFile(in)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	golden, err := ioutil.ReadFile(out)
+	golden, err := os.ReadFile(out)
 	if err != nil {
 		t.Error(err)
 		return
@@ -157,7 +156,7 @@ func TestPrintParse(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			data, err := ioutil.ReadFile(out)
+			data, err := os.ReadFile(out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -212,7 +211,7 @@ func TestPrintParse(t *testing.T) {
 			}
 
 			if strings.HasSuffix(out, ".in") {
-				golden, err := ioutil.ReadFile(strings.TrimSuffix(out, ".in") + ".golden")
+				golden, err := os.ReadFile(strings.TrimSuffix(out, ".in") + ".golden")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -346,14 +345,14 @@ func (eq *eqchecker) checkValue(v, w reflect.Value) error {
 
 // diff returns the output of running diff on b1 and b2.
 func diff(b1, b2 []byte) (data []byte, err error) {
-	f1, err := ioutil.TempFile("", "testdiff")
+	f1, err := os.CreateTemp("", "testdiff")
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(f1.Name())
 	defer f1.Close()
 
-	f2, err := ioutil.TempFile("", "testdiff")
+	f2, err := os.CreateTemp("", "testdiff")
 	if err != nil {
 		return nil, err
 	}

--- a/modfile/work_test.go
+++ b/modfile/work_test.go
@@ -6,7 +6,7 @@ package modfile
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -308,7 +308,7 @@ func TestWorkPrintParse(t *testing.T) {
 		name := filepath.Base(out)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			data, err := ioutil.ReadFile(out)
+			data, err := os.ReadFile(out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -360,7 +360,7 @@ func TestWorkPrintParse(t *testing.T) {
 			}
 
 			if strings.HasSuffix(out, ".in") {
-				golden, err := ioutil.ReadFile(strings.TrimSuffix(out, ".in") + ".golden")
+				golden, err := os.ReadFile(strings.TrimSuffix(out, ".in") + ".golden")
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/sumdb/dirhash/hash_test.go
+++ b/sumdb/dirhash/hash_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ func htop(k string, s string) string {
 func TestHash1(t *testing.T) {
 	files := []string{"xyz", "abc"}
 	open := func(name string) (io.ReadCloser, error) {
-		return ioutil.NopCloser(strings.NewReader("data for " + name)), nil
+		return io.NopCloser(strings.NewReader("data for " + name)), nil
 	}
 	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "abc", h("data for xyz"), "xyz"))
 	out, err := Hash1(files, open)
@@ -47,15 +46,15 @@ func TestHash1(t *testing.T) {
 }
 
 func TestHashDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dirhash-test-")
+	dir, err := os.MkdirTemp("", "dirhash-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
 		t.Fatal(err)
 	}
 	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "prefix/abc", h("data for xyz"), "prefix/xyz"))
@@ -69,7 +68,7 @@ func TestHashDir(t *testing.T) {
 }
 
 func TestHashZip(t *testing.T) {
-	f, err := ioutil.TempFile("", "dirhash-test-")
+	f, err := os.CreateTemp("", "dirhash-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,21 +105,21 @@ func TestHashZip(t *testing.T) {
 
 func TestDirFiles(t *testing.T) {
 	t.Run("valid directory with files", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "dirfiles-test-")
+		dir, err := os.MkdirTemp("", "dirfiles-test-")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.RemoveAll(dir)
-		if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.Mkdir(filepath.Join(dir, "subdir"), 0777); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0666); err != nil {
 			t.Fatal(err)
 		}
 		prefix := "foo/bar@v2.3.4"

--- a/sumdb/tlog/ct_test.go
+++ b/sumdb/tlog/ct_test.go
@@ -7,7 +7,7 @@ package tlog
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -80,7 +80,7 @@ func httpGET(t *testing.T, url string, targ interface{}) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zip/zip.go
+++ b/zip/zip.go
@@ -51,7 +51,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -753,7 +752,7 @@ func Unzip(dir string, m module.Version, zipFile string) (err error) {
 
 	// Check that the directory is empty. Don't create it yet in case there's
 	// an error reading the zip.
-	if files, _ := ioutil.ReadDir(dir); len(files) > 0 {
+	if files, _ := os.ReadDir(dir); len(files) > 0 {
 		return fmt.Errorf("target directory %v exists and is not empty", dir)
 	}
 


### PR DESCRIPTION
This PR replaces the deprecated in Go 1.17 `io/ioutil` package with `io` and `os` packages.

Changes are the same as in #14 but with test fixes.