### PR TITLE
sumdb/tlog: fuzz tests for parsers

### DIFF
--- a/sumdb/tlog/note_test.go
+++ b/sumdb/tlog/note_test.go
@@ -115,3 +115,17 @@ func TestParseRecord(t *testing.T) {
 		}
 	}
 }
+
+func FuzzParseTree(f *testing.F) {
+	f.Add([]byte("go.sum database tree\n123456789012\nTszzRgjTG6xce+z2AG31kAXYKBgQVtCSCE40HmuwBb0=\n"))
+	f.Fuzz(func(t *testing.T, text []byte) {
+		ParseTree(text)
+	})
+}
+
+func FuzzParseRecord(f *testing.F) {
+	f.Add([]byte("12345\nhello\n\n"))
+	f.Fuzz(func(t *testing.T, msg []byte) {
+		ParseRecord(msg)
+	})
+}

--- a/sumdb/tlog/note_test.go
+++ b/sumdb/tlog/note_test.go
@@ -116,6 +116,7 @@ func TestParseRecord(t *testing.T) {
 	}
 }
 
+// FuzzParseTree tests that ParseTree never crashes
 func FuzzParseTree(f *testing.F) {
 	f.Add([]byte("go.sum database tree\n123456789012\nTszzRgjTG6xce+z2AG31kAXYKBgQVtCSCE40HmuwBb0=\n"))
 	f.Fuzz(func(t *testing.T, text []byte) {
@@ -123,6 +124,7 @@ func FuzzParseTree(f *testing.F) {
 	})
 }
 
+// FuzzParseRecord tests that ParseRecord never crashes
 func FuzzParseRecord(f *testing.F) {
 	f.Add([]byte("12345\nhello\n\n"))
 	f.Fuzz(func(t *testing.T, msg []byte) {

--- a/sumdb/tlog/tile_test.go
+++ b/sumdb/tlog/tile_test.go
@@ -1,0 +1,24 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tlog
+
+import (
+	"testing"
+)
+
+// FuzzParseTilePath tests that ParseTilePath never crashes
+func FuzzParseTilePath(f *testing.F) {
+	f.Add("tile/4/0/001")
+	f.Add("tile/4/0/001.p/5")
+	f.Add("tile/3/5/x123/x456/078")
+	f.Add("tile/3/5/x123/x456/078.p/2")
+	f.Add("tile/1/0/x003/x057/500")
+	f.Add("tile/3/5/123/456/078")
+	f.Add("tile/3/-1/123/456/078")
+	f.Add("tile/1/data/x003/x057/500")
+	f.Fuzz(func(t *testing.T, path string) {
+		ParseTilePath(path)
+	})
+}


### PR DESCRIPTION
Future fuzz tests could test round trip properties