### PR TITLE
fix: Don't exclude go.mod hashes

### DIFF
--- a/sumdb/client.go
+++ b/sumdb/client.go
@@ -282,7 +282,7 @@ func (c *Client) Lookup(path, vers string) (lines []string, err error) {
 
 	// Extract the lines for the specific version we want
 	// (with or without /go.mod).
-	prefix := path + " " + vers + " "
+	prefix := path + " " + vers
 	var hashes []string
 	for _, line := range strings.Split(string(result.data), "\n") {
 		if strings.HasPrefix(line, prefix) {


### PR DESCRIPTION
The prefix check for valid module lines currently excludes hashes for the
`go.mod` hash, when the comment immediately above this line seems to
indicate this isn't the intended behavior. The prefix check is updated
here to include those lines.