### PR TITLE
fix: AddNewRequire block ordering

### DIFF
--- a/modfile/rule.go
+++ b/modfile/rule.go
@@ -1144,7 +1144,7 @@ func (f *File) addNewGodebug(key, value string) {
 // other lines for path.
 //
 // If no line currently exists for path, AddRequire adds a new line
-// at the end of the last require block.
+// using AddNewRequire.
 func (f *File) AddRequire(path, vers string) error {
 	need := true
 	for _, r := range f.Require {
@@ -1166,10 +1166,14 @@ func (f *File) AddRequire(path, vers string) error {
 	return nil
 }
 
-// AddNewRequire adds a new require line for path at version vers at the end of
-// the last require block, regardless of any existing require lines for path.
+// AddNewRequire adds a new require line for path at version vers, regardless
+// of any existing require lines for path.
+// Similar to SetRequireSeparateIndirect it attempts to maintain the standard
+// of having direct requires in the first block and indirect requires in the
+// second block.
 func (f *File) AddNewRequire(path, vers string, indirect bool) {
-	line := f.Syntax.addLine(nil, "require", AutoQuote(path), vers)
+	hint := f.Syntax.requireHint(indirect)
+	line := f.Syntax.addLine(hint, "require", AutoQuote(path), vers)
 	r := &Require{
 		Mod:    module.Version{Path: path, Version: vers},
 		Syntax: line,
@@ -1248,6 +1252,12 @@ func (f *File) SetRequire(req []*Require) {
 // If the file initially has one uncommented block of requirements,
 // SetRequireSeparateIndirect will split it into a direct-only and indirect-only
 // block. This aids in the transition to separate blocks.
+//
+// New entries in req must not be added to the file.Require slice before calling
+// otherwise this function will panic. So the calling convention should be along
+// the lines of:
+//
+//	File.SetRequireSeparateIndirect(append(File.Require, newReqs...))
 func (f *File) SetRequireSeparateIndirect(req []*Require) {
 	// hasComments returns whether a line or block has comments
 	// other than "indirect".

--- a/modfile/rule_test.go
+++ b/modfile/rule_test.go
@@ -13,6 +13,240 @@ import (
 	"golang.org/x/mod/module"
 )
 
+var addNewRequireTests = []struct {
+	desc string
+	in   string
+	mods []require
+	out  string
+}{
+	{
+		`golden`,
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/b v1.2.3
+			x.y/c v1.2.3
+		)
+
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+			x.y/f v1.2.3 // indirect
+		)
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/b v1.2.3
+			x.y/c v1.2.3
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+			x.y/f v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`empty`,
+		`module m
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`empty_direct`,
+		`module m
+		`,
+		[]require{
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+		`,
+	},
+	{
+		`direct_line`,
+		`module m
+		require x.y/a v1.2.3
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`direct_block`,
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/b v1.2.3
+		)
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/a v1.2.3
+			x.y/b v1.2.3
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`indirect_line`,
+		`module m
+		require x.y/d v1.2.3 // indirect
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`indirect_block`,
+		`module m
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+		)
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`module m
+		require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`indirect_block_no_module`,
+		`require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+		)
+		`,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/d v1.2.3 // indirect
+			x.y/e v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+	{
+		`no_module`,
+		``,
+		[]require{
+			{"x.y/g", "v1.2.3", true},
+			{"x.y/h", "v1.2.3", false},
+			{"x.y/i", "v1.2.3", true},
+			{"x.y/k", "v1.2.3", false},
+		},
+		`require (
+			x.y/h v1.2.3
+			x.y/k v1.2.3
+		)
+
+		require (
+			x.y/g v1.2.3 // indirect
+			x.y/i v1.2.3 // indirect
+		)
+		`,
+	},
+}
+
 var addRequireTests = []struct {
 	desc string
 	in   string
@@ -83,11 +317,13 @@ var addRequireTests = []struct {
 		"x.y/w", "v1.5.6",
 		`
 		module m
-		require x.y/z v1.2.3
+
 		require (
-			x.y/q/v2 v2.3.4
+			x.y/z v1.2.3
 			x.y/w v1.5.6
 		)
+
+		require x.y/q/v2 v2.3.4
 		`,
 	},
 	{
@@ -222,7 +458,10 @@ var setRequireTests = []struct {
 			{"x.y/g", "v1.2.3", false},
 		},
 		`module m
-		require x.y/a v1.2.3
+		require (
+			x.y/a v1.2.3
+			x.y/h v1.2.3
+		)
 
 		require x.y/b v1.2.3
 
@@ -234,10 +473,7 @@ var setRequireTests = []struct {
 
 		require x.y/f v1.2.3
 
-		require (
-			x.y/g v1.2.3
-			x.y/h v1.2.3
-		)
+		require x.y/g v1.2.3
 		`,
 	},
 	{
@@ -1794,6 +2030,21 @@ func TestAddRequire(t *testing.T) {
 				err := f.AddRequire(tt.path, tt.vers)
 				f.Cleanup()
 				return err
+			})
+		})
+	}
+}
+
+func TestAddNewRequire(t *testing.T) {
+	for _, tt := range addNewRequireTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			testEdit(t, tt.in, tt.out, true, func(f *File) error {
+				for _, mod := range tt.mods {
+					f.AddNewRequire(mod.path, mod.vers, mod.indirect)
+					f.Cleanup()
+					f.SortBlocks()
+				}
+				return nil
 			})
 		})
 	}


### PR DESCRIPTION
Try to maintain the expected block ordering with direct requires in the first block and indirect requires in the second block.

Also clarify expected use of SetRequireSeparateIndirect to avoid panic.

Fixes #69050