### PR TITLE
go.mod: relax the Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module golang.org/x/mod
 
-go 1.22.0
+go 1.22
 
 require golang.org/x/tools v0.13.0 // tagx:ignore


### PR DESCRIPTION
Reverts CL 605935.

The toolchain issue should not be the reason to bump
the required Go version.
https://go.dev/ref/mod does not recommend setting the patch
version in the go directive.